### PR TITLE
Should use Vinyl.base to create relative compiled files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,12 +12,10 @@ var sources = [
 	'!src/typescript/lib*.ts'
 ];
 
-var target = '';
-
 gulp.task('build', function() {
 	return gulp.src(sources)
 		.pipe(compilation())
-		.pipe(gulp.dest(target));
+		.pipe(gulp.dest('src'));
 });
 
 gulp.task('dev', ['build'], function() {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -262,7 +262,7 @@ function createCompilerOptions(config: IConfiguration): ts.CompilerOptions {
 }
 
 class ScriptSnapshot implements ts.IScriptSnapshot {
-    
+
     private _text: string;
     private _mtime: Date;
 


### PR DESCRIPTION
One should be able to do this:

```javascript
gulp.task('build', function() {
	return gulp.src('src/**/*.ts', { base: 'src' })
		.pipe(compilation())
		.pipe(gulp.dest('out'));
});
```