### PR TITLE
Use outDir as vinyl base when provided

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -46,6 +46,14 @@ function createTypeScriptBuilder(config) {
     function file(file) {
         host.addScriptSnapshot(file.path, new VinylScriptSnapshot(file));
     }
+    function baseFor(snapshot) {
+        if (snapshot instanceof VinylScriptSnapshot) {
+            return compilerOptions.outDir || snapshot.getBase();
+        }
+        else {
+            return '';
+        }
+    }
     function build(out, onError) {
         var filenames = host.getScriptFileNames(), newErrors = Object.create(null), checkedThisRound = Object.create(null), filesWithShapeChanges = [], t1 = Date.now();
         function shouldCheck(filename) {
@@ -82,7 +90,7 @@ function createTypeScriptBuilder(config) {
                 out(new Vinyl({
                     path: file.name,
                     contents: new Buffer(file.text),
-                    base: snapshot instanceof VinylScriptSnapshot ? snapshot.getBase() : ''
+                    base: baseFor(snapshot)
                 }));
             });
             // print and store syntax and semantic errors

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -76,6 +76,14 @@ export function createTypeScriptBuilder(config: IConfiguration): ITypeScriptBuil
     function file(file: Vinyl): void {
         host.addScriptSnapshot(file.path, new VinylScriptSnapshot(file));
     }
+    
+    function baseFor(snapshot: ScriptSnapshot): string {
+        if (snapshot instanceof VinylScriptSnapshot) {
+            return compilerOptions.outDir || snapshot.getBase();
+        } else {
+            return '';
+        }
+    }
 
     function build(out: (file: Vinyl) => void, onError: (err: any) => void): void {
 
@@ -128,11 +136,11 @@ export function createTypeScriptBuilder(config: IConfiguration): ITypeScriptBuil
                 }
 
                 _log('[emit output]', file.name);
-
+                
                 out(new Vinyl({
                     path: file.name,
                     contents: new Buffer(file.text),
-                    base: snapshot instanceof VinylScriptSnapshot ? snapshot.getBase() : ''
+                    base: baseFor(snapshot)
                 }));
             });
 


### PR DESCRIPTION
When the user actually provides `outDir` via the compiler configuration, the vinyl files emitted by gulp-tsb could be based on that.