### PR TITLE
Add support to gulp-sourcemaps

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -22,7 +22,7 @@ function normalize(path) {
     return path.replace(/\\/g, '/');
 }
 function createTypeScriptBuilder(config) {
-    var compilerOptions = createCompilerOptions(config), host = new LanguageServiceHost(compilerOptions), service = ts.createLanguageService(host, ts.createDocumentRegistry()), lastBuildVersion = Object.create(null), lastDtsHash = Object.create(null), userWantsDeclarations = compilerOptions.declaration, oldErrors = Object.create(null), headUsed = process.memoryUsage().heapUsed;
+    var compilerOptions = createCompilerOptions(config), host = new LanguageServiceHost(compilerOptions), service = ts.createLanguageService(host, ts.createDocumentRegistry()), lastBuildVersion = Object.create(null), lastDtsHash = Object.create(null), userWantsDeclarations = compilerOptions.declaration, oldErrors = Object.create(null), headUsed = process.memoryUsage().heapUsed, emitSourceMapsInStream = true;
     // always emit declaraction files
     host.getCompilationSettings().declaration = true;
     if (!host.getCompilationSettings().noLib) {
@@ -50,6 +50,10 @@ function createTypeScriptBuilder(config) {
         onError(message);
     }
     function file(file) {
+        // support gulp-sourcemaps
+        if (file.sourceMap) {
+            emitSourceMapsInStream = false;
+        }
         if (!file.contents) {
             host.removeScriptSnapshot(file.path);
         }
@@ -92,6 +96,9 @@ function createTypeScriptBuilder(config) {
                     var signature;
                     for (var _i = 0, _a = output.outputFiles; _i < _a.length; _i++) {
                         var file_1 = _a[_i];
+                        if (!emitSourceMapsInStream && /\.js\.map$/.test(file_1.name)) {
+                            continue;
+                        }
                         if (/\.d\.ts$/.test(file_1.name)) {
                             signature = crypto.createHash('md5')
                                 .update(file_1.text)
@@ -101,11 +108,24 @@ function createTypeScriptBuilder(config) {
                                 continue;
                             }
                         }
-                        files.push(new Vinyl({
+                        var vinyl = new Vinyl({
                             path: file_1.name,
                             contents: new Buffer(file_1.text),
                             base: !config._emitWithoutBasePath && baseFor(host.getScriptSnapshot(fileName))
-                        }));
+                        });
+                        if (!emitSourceMapsInStream && /\.js$/.test(file_1.name)) {
+                            var sourcemapFile = output.outputFiles.filter(function (f) { return /\.js\.map$/.test(f.name); })[0];
+                            if (sourcemapFile) {
+                                var extname = path.extname(vinyl.relative);
+                                var basename = path.basename(vinyl.relative, extname);
+                                var dirname = path.dirname(vinyl.relative);
+                                var tsname = (dirname === '.' ? '' : dirname + '/') + basename + '.ts';
+                                var sourceMap = JSON.parse(sourcemapFile.text);
+                                sourceMap.sources[0] = tsname;
+                                vinyl.sourceMap = sourceMap;
+                            }
+                        }
+                        files.push(vinyl);
                     }
                     resolve({
                         fileName: fileName,


### PR DESCRIPTION
You still need to tell the TS compiler `"sourceMap": true` but you can now do stuff like this:

```javascript
gulp.task('compile2', ['clean'], function () {
	return gulp.src('src/**/*.ts', { base: 'src' })
		.pipe(sourcemaps.init())
		.pipe(compilation())
		// pipe to other sourcemap changing things, like concat, uglify, etc
		.pipe(sourcemaps.write('.', { includeContent: true }))
		.pipe(gulp.dest('out'));
});
```