### PR TITLE
Add support for 'jsx' compiler options handling.

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -318,6 +318,16 @@ function createCompilerOptions(config) {
     else if (/amd/i.test(String(config['module']))) {
         config['module'] = 2 /* AMD */;
     }
+    // jsx handling
+    if (/none/i.test(String(config['jsx']))) {
+        config['jsx'] = 0 /* None */;
+    }
+    else if (/preserve/i.test(String(config['jsx']))) {
+        config['jsx'] = 1 /* Preserve */;
+    }
+    else if (/react/i.test(String(config['jsx']))) {
+        config['jsx'] = 2 /* React */;
+    }
     return config;
 }
 var ScriptSnapshot = (function () {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -406,6 +406,15 @@ function createCompilerOptions(config: IConfiguration): ts.CompilerOptions {
         config['module'] = ts.ModuleKind.AMD;
     }
 
+    // jsx handling
+    if (/none/i.test(String(config['jsx']))) {
+        config['jsx'] = ts.JsxEmit.None;
+    } else if (/preserve/i.test(String(config['jsx']))) {
+        config['jsx'] = ts.JsxEmit.Preserve;
+    } else if (/react/i.test(String(config['jsx']))) {
+        config['jsx'] = ts.JsxEmit.React;
+    }
+
     return <ts.CompilerOptions> config;
 }
 


### PR DESCRIPTION
Typescript's typescriptServices.js compares compilerOptions.jsx to three integer values to determine how JSX syntax is processed.

The 'jsx' compiler option is specified in the tsconfig.json file; which, is read in by gulp-tsb and transformed by createCompilerOptions to map human friendly string values to parse performance friendly integer values.

Builder.js can support the JSX compiler option by applying code very similar to its handling for module and target.