### PR TITLE
Extend builder's compiler options to include new typescript targets and module outputs

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -298,36 +298,35 @@ function createTypeScriptBuilder(config) {
 }
 exports.createTypeScriptBuilder = createTypeScriptBuilder;
 function createCompilerOptions(config) {
+    function map(key, map, defaultValue) {
+        key = key.toLowerCase();
+        if (map.hasOwnProperty(key)) {
+            return map[key];
+        }
+        return defaultValue;
+    }
     // language version
-    if (!config['target']) {
-        config['target'] = 0 /* ES3 */;
-    }
-    else if (/ES3/i.test(String(config['target']))) {
-        config['target'] = 0 /* ES3 */;
-    }
-    else if (/ES5/i.test(String(config['target']))) {
-        config['target'] = 1 /* ES5 */;
-    }
-    else if (/ES6/i.test(String(config['target']))) {
-        config['target'] = 2 /* ES6 */;
-    }
+    config['target'] = map(String(config['target']), {
+        es3: 0 /* ES3 */,
+        es5: 1 /* ES5 */,
+        es6: 2 /* ES6 */,
+        es2015: 2 /* ES2015 */,
+        latest: 2 /* Latest */
+    }, 0 /* ES3 */);
     // module generation
-    if (/commonjs/i.test(String(config['module']))) {
-        config['module'] = 1 /* CommonJS */;
-    }
-    else if (/amd/i.test(String(config['module']))) {
-        config['module'] = 2 /* AMD */;
-    }
+    config['module'] = map(String(config['module']), {
+        commonjs: 1 /* CommonJS */,
+        amd: 2 /* AMD */,
+        system: 4 /* System */,
+        umd: 3 /* UMD */,
+        es6: 5 /* ES6 */,
+        es2015: 5 /* ES2015 */
+    }, 0 /* None */);
     // jsx handling
-    if (/none/i.test(String(config['jsx']))) {
-        config['jsx'] = 0 /* None */;
-    }
-    else if (/preserve/i.test(String(config['jsx']))) {
-        config['jsx'] = 1 /* Preserve */;
-    }
-    else if (/react/i.test(String(config['jsx']))) {
-        config['jsx'] = 2 /* React */;
-    }
+    config['jsx'] = map(String(config['jsx']), {
+        preserve: 1 /* Preserve */,
+        react: 2 /* React */
+    }, 0 /* None */);
     return config;
 }
 var ScriptSnapshot = (function () {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -388,32 +388,38 @@ export function createTypeScriptBuilder(config: IConfiguration): ITypeScriptBuil
 
 function createCompilerOptions(config: IConfiguration): ts.CompilerOptions {
 
-    // language version
-    if (!config['target']) {
-        config['target'] = ts.ScriptTarget.ES3;
-    } else if (/ES3/i.test(String(config['target']))) {
-        config['target'] = ts.ScriptTarget.ES3;
-    } else if (/ES5/i.test(String(config['target']))) {
-        config['target'] = ts.ScriptTarget.ES5;
-    } else if (/ES6/i.test(String(config['target']))) {
-        config['target'] = ts.ScriptTarget.ES6;
+    function map<T>(key:any, map:{[key:string]:T}, defaultValue:T):T {
+        let s = String(key).toLowerCase();
+        if (map.hasOwnProperty(s)) {
+            return map[s];
+        }
+        return defaultValue;
     }
+
+    // language version
+    config['target'] = map(config['target'], {
+        es3: ts.ScriptTarget.ES3,
+        es5: ts.ScriptTarget.ES5,
+        es6: ts.ScriptTarget.ES6,
+        es2015: ts.ScriptTarget.ES2015,
+        latest: ts.ScriptTarget.Latest
+    }, ts.ScriptTarget.ES3);
 
     // module generation
-    if (/commonjs/i.test(String(config['module']))) {
-        config['module'] = ts.ModuleKind.CommonJS;
-    } else if (/amd/i.test(String(config['module']))) {
-        config['module'] = ts.ModuleKind.AMD;
-    }
+    config['module'] = map(config['module'], {
+        commonjs: ts.ModuleKind.CommonJS,
+        amd: ts.ModuleKind.AMD,
+        system: ts.ModuleKind.System,
+        umd: ts.ModuleKind.UMD,
+        es6: ts.ModuleKind.ES6,
+        es2015: ts.ModuleKind.ES2015
+    }, ts.ModuleKind.None);
 
     // jsx handling
-    if (/none/i.test(String(config['jsx']))) {
-        config['jsx'] = ts.JsxEmit.None;
-    } else if (/preserve/i.test(String(config['jsx']))) {
-        config['jsx'] = ts.JsxEmit.Preserve;
-    } else if (/react/i.test(String(config['jsx']))) {
-        config['jsx'] = ts.JsxEmit.React;
-    }
+    config['jsx'] = map(config['jsx'], {
+        preserve: ts.JsxEmit.Preserve,
+        react: ts.JsxEmit.React
+    }, ts.JsxEmit.None);
 
     return <ts.CompilerOptions> config;
 }


### PR DESCRIPTION
Created a helper map function to remove `if` - `else if` branches.

Also closes issue #14.