### PR TITLE
fix getDefaultLibFileName returning incorrect path for flattened node_modules

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -444,7 +444,8 @@ var LanguageServiceHost = (function () {
         return process.cwd();
     };
     LanguageServiceHost.prototype.getDefaultLibFileName = function (options) {
-        return path.join(__dirname, '../node_modules/typescript/lib', options.target < 2 /* ES6 */ ? 'lib.d.ts' : 'lib.es6.d.ts');
+        var libFile = options.target < 2 /* ES6 */ ? 'lib.d.ts' : 'lib.es6.d.ts';
+        return require.resolve("typescript/lib/" + libFile);
     };
     // ---- dependency management
     LanguageServiceHost.prototype.collectDependents = function (filename, target) {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -572,7 +572,8 @@ class LanguageServiceHost implements ts.LanguageServiceHost {
     }
 
     getDefaultLibFileName(options: ts.CompilerOptions): string {
-        return path.join(__dirname, '../node_modules/typescript/lib', options.target < ts.ScriptTarget.ES6 ? 'lib.d.ts' : 'lib.es6.d.ts');
+        let libFile = options.target < ts.ScriptTarget.ES6 ? 'lib.d.ts' : 'lib.es6.d.ts';
+        return require.resolve("typescript/lib/" + libFile);
     }
 
     // ---- dependency management


### PR DESCRIPTION
In case of npm 3, the node_modules directory is flattened as much as possible, thus for most of the time, npm will move gulp-tsb's typescript dependency outside of gulp-tsb's package. This PR fixes this, by using `require.resolve` to resolve the typescript package path.