### PR TITLE
Add noFilesystemLookup option which disables extra files lookup

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -21,7 +21,7 @@ function normalize(path) {
     return path.replace(/\\/g, '/');
 }
 function createTypeScriptBuilder(config) {
-    var compilerOptions = createCompilerOptions(config), host = new LanguageServiceHost(compilerOptions), service = ts.createLanguageService(host, ts.createDocumentRegistry()), lastBuildVersion = Object.create(null), lastDtsHash = Object.create(null), userWantsDeclarations = compilerOptions.declaration, oldErrors = Object.create(null), headUsed = process.memoryUsage().heapUsed, emitSourceMapsInStream = true;
+    var compilerOptions = createCompilerOptions(config), host = new LanguageServiceHost(compilerOptions, config.noFilesystemLookup || false), service = ts.createLanguageService(host, ts.createDocumentRegistry()), lastBuildVersion = Object.create(null), lastDtsHash = Object.create(null), userWantsDeclarations = compilerOptions.declaration, oldErrors = Object.create(null), headUsed = process.memoryUsage().heapUsed, emitSourceMapsInStream = true;
     // always emit declaraction files
     host.getCompilationSettings().declaration = true;
     function _log(topic, message) {
@@ -356,8 +356,9 @@ var VinylScriptSnapshot = (function (_super) {
     return VinylScriptSnapshot;
 })(ScriptSnapshot);
 var LanguageServiceHost = (function () {
-    function LanguageServiceHost(settings) {
+    function LanguageServiceHost(settings, noFilesystemLookup) {
         this._settings = settings;
+        this._noFilesystemLookup = noFilesystemLookup;
         this._snapshots = Object.create(null);
         this._dependencies = new utils.graph.Graph(function (s) { return s; });
         this._dependenciesRecomputeList = [];
@@ -385,7 +386,7 @@ var LanguageServiceHost = (function () {
     LanguageServiceHost.prototype.getScriptSnapshot = function (filename) {
         filename = normalize(filename);
         var result = this._snapshots[filename];
-        if (!result) {
+        if (!result && !this._noFilesystemLookup) {
             try {
                 result = new VinylScriptSnapshot(new Vinyl({
                     path: filename,

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -10,6 +10,7 @@ import Vinyl = require('vinyl');
 
 export interface IConfiguration {
     json: boolean;
+    noFilesystemLookup: boolean;
     verbose: boolean;
     _emitWithoutBasePath?: boolean;
     _emitLanguageService?: boolean;
@@ -38,7 +39,7 @@ function normalize(path: string): string {
 export function createTypeScriptBuilder(config: IConfiguration): ITypeScriptBuilder {
 
     var compilerOptions = createCompilerOptions(config),
-        host = new LanguageServiceHost(compilerOptions),
+        host = new LanguageServiceHost(compilerOptions, config.noFilesystemLookup || false),
         service = ts.createLanguageService(host, ts.createDocumentRegistry()),
         lastBuildVersion: { [path: string]: string } = Object.create(null),
         lastDtsHash: { [path: string]: string } = Object.create(null),
@@ -463,13 +464,15 @@ class VinylScriptSnapshot extends ScriptSnapshot {
 class LanguageServiceHost implements ts.LanguageServiceHost {
 
     private _settings: ts.CompilerOptions;
+    private _noFilesystemLookup: boolean;
     private _snapshots: { [path: string]: ScriptSnapshot };
     private _dependencies: utils.graph.Graph<string>;
     private _dependenciesRecomputeList: string[];
     private _fileNameToDeclaredModule: { [path: string]: string[] };
 
-    constructor(settings: ts.CompilerOptions) {
+    constructor(settings: ts.CompilerOptions, noFilesystemLookup:boolean) {
         this._settings = settings;
+        this._noFilesystemLookup = noFilesystemLookup;
         this._snapshots = Object.create(null);
         this._dependencies = new utils.graph.Graph<string>(s => s);
         this._dependenciesRecomputeList = [];
@@ -504,7 +507,7 @@ class LanguageServiceHost implements ts.LanguageServiceHost {
     getScriptSnapshot(filename: string): ScriptSnapshot {
         filename = normalize(filename);
         let result = this._snapshots[filename];
-        if (!result) {
+        if (!result && !this._noFilesystemLookup) {
             try {
                 result = new VinylScriptSnapshot(new Vinyl(<any> {
                     path: filename,


### PR DESCRIPTION
Added noFilesystemLookup option that we can adopt in vscode's gulp scripts to prevent additional TypeScript amd path lookups. This works because in vscode's gulp scripts we feed all the existing TypeScript files up-front and there is no point in looking for extra files on disk since they will not be there.