### PR TITLE
Always parse TSCONFIG file as UTF-8

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export function create(configOrName: builder.IConfiguration|string, verbose?: bo
 
     var config: builder.IConfiguration;
     if (typeof configOrName === 'string') {
-        var parsed = readConfigFile(configOrName, (path) => readFileSync(path, undefined));
+        var parsed = readConfigFile(configOrName, (path) => readFileSync(path, 'utf-8'));
         if (parsed.error) {
             console.error(parsed.error);
             return () => null;


### PR DESCRIPTION
On mac Mac I had problems that the TSCONFIG file were being parsed as a buffer and not a string, which caused the TypeScript compiler to fail with:
`messageText: 'Failed to parse file \'tsconfig.json\': text.charCodeAt is not a function.',`

This solves it.