### PR TITLE
Set better config base path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import * as builder from './builder';
 import * as ts from 'typescript';
 import {Stream} from 'stream';
 import {readFileSync, existsSync, readdirSync} from 'fs';
-import {extname} from 'path';
+import {extname, dirname} from 'path';
 
 // We actually only want to read the tsconfig.json file. So all methods
 // to read the FS are 'empty' implementations.
@@ -37,13 +37,13 @@ export function create(configOrName: { [option: string]: string | number | boole
 
     if (typeof configOrName === 'string') {
         var parsed = ts.readConfigFile(configOrName, _parseConfigHost.readFile);
-        options = ts.parseJsonConfigFileContent(parsed.config, _parseConfigHost, __dirname).options;
+        options = ts.parseJsonConfigFileContent(parsed.config, _parseConfigHost, dirname(configOrName)).options;
         if (parsed.error) {
             console.error(parsed.error);
             return () => null;
         }
     } else {
-        options = ts.parseJsonConfigFileContent({ compilerOptions: configOrName }, _parseConfigHost, __dirname).options;
+        options = ts.parseJsonConfigFileContent({ compilerOptions: configOrName }, _parseConfigHost, './').options;
         Object.assign(config, configOrName);
     }
 


### PR DESCRIPTION
Fixes #48

The doc for basepath says:

basePath A root directory to resolve relative path entries in the config.

The basepath and the pathes in the config file will be used for the source location in source map files.

For the case where a config is passed by content, I suggest to use the current working dir. Ideally there would be an additional argument.