### PR TITLE
Add LKG support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 npm-debug.log
-lib/
+out/
+tmp/

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,7 @@
-src
-typings
 .vscode
+src
+tmp
+out
+typings
 gulpfile.js
 tsconfig.json

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,23 +2,100 @@
 
 var gulp = require('gulp');
 var path = require('path');
-var tsb = require('./lib/index');
-
-var compilation = tsb.create(path.join(__dirname, 'tsconfig.json'), true);
+var mocha = require('gulp-mocha');
+var del = require('del');
+var runSequence = require('run-sequence');
+var tsb = require('./lib');
+var compilation = tsb.create('./tsconfig.json', /*verbose*/ true);
 
 var sources = [
-	'src/**/*.ts',
-	'node_modules/@types/**/*.ts'
+    'src/**/*.ts',
+    'node_modules/@types/**/*.ts'
 ];
 
-gulp.task('build', function () {
-	return gulp.src(sources)
-		.pipe(compilation())
-		.pipe(gulp.dest('lib'));
+var latest = [
+    'out/**/*.js',
+    'out/**/*.js.map',
+    'out/**/*.d.ts'
+];
+
+// build latest using LKG version
+gulp.task('pre-build', function() {
+    return gulp.src(sources)
+        .pipe(compilation())
+        .pipe(gulp.dest('tmp'));
+})
+
+// re-build latest using built version
+gulp.task('build', ['pre-build'], function () {
+    var tsb = reload('./tmp');
+    var compilation = tsb.create('./tsconfig.json', /*verbose*/ true);
+    return gulp.src(sources)
+        .pipe(compilation())
+        .pipe(gulp.dest('out'));
 });
 
-gulp.task('dev', ['build'], function () {
-	gulp.watch(sources, ['build']);
+// clean built versions
+gulp.task('clean', function () {
+    return del(['tmp', 'out']);
+});
+
+// clean the lkg
+gulp.task('lkg:clean', function () {
+    return del(['lib']);
+});
+
+// copy files for 'lkg' task
+gulp.task('lkg:copy', ['lkg:clean'], function () {
+    return gulp.src(latest).pipe(gulp.dest('lib'));
+});
+
+// deploy lkg
+gulp.task('lkg', function () {
+    return runSequence('clean', 'test', 'lkg:copy');
+});
+
+gulp.task('test', ['build'], function () {
+    return gulp.src(["out/tests/**/*.js"], { read: false })
+        .pipe(mocha({ timeout: 3000 }));
+});
+
+gulp.task('dev', ['test'], function () {
+    return gulp.watch(sources, ['test']);
 });
 
 gulp.task('default', ['dev']);
+
+// reload a node module and any children beneath the same folder
+function reload(moduleName) {
+    var id = require.resolve(moduleName);
+    var mod = require.cache[id];
+    if (mod) {
+        var base = path.dirname(mod.filename);
+        // expunge each module cache entry beneath this folder
+        var stack = [mod];
+        while (stack.length) {
+            var mod = stack.pop();
+            if (beneathBase(mod.filename)) {
+                delete require.cache[mod.id];
+            }
+            stack.push.apply(stack, mod.children);
+        }
+    }
+
+    // expunge each path cache entry beneath the folder
+    for (var cacheKey in module.constructor._pathCache) {
+        if (cacheKey.indexOf(moduleName) > 0 && beneathBase(cacheKey)) {
+            delete module.constructor._pathCache[cacheKey];
+        }
+    }
+
+    // re-require the module
+    return require(moduleName);
+
+    function beneathBase(file) {
+        return base === undefined
+            || (file.length > base.length
+                && file.substr(0, base.length + 1) === base + path.sep);
+    }
+}

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,0 +1,488 @@
+'use strict';
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var fs_1 = require("fs");
+var path = require("path");
+var crypto = require("crypto");
+var utils = require("./utils");
+var gulp_util_1 = require("gulp-util");
+var ts = require("typescript");
+var Vinyl = require("vinyl");
+var CancellationToken;
+(function (CancellationToken) {
+    CancellationToken.None = {
+        isCancellationRequested: function () { return false; }
+    };
+})(CancellationToken = exports.CancellationToken || (exports.CancellationToken = {}));
+function normalize(path) {
+    return path.replace(/\\/g, '/');
+}
+function createTypeScriptBuilder(config, compilerOptions) {
+    var host = new LanguageServiceHost(compilerOptions, config.noFilesystemLookup || false), service = ts.createLanguageService(host, ts.createDocumentRegistry()), lastBuildVersion = Object.create(null), lastDtsHash = Object.create(null), userWantsDeclarations = compilerOptions.declaration, oldErrors = Object.create(null), headUsed = process.memoryUsage().heapUsed, emitSourceMapsInStream = true;
+    // always emit declaraction files
+    host.getCompilationSettings().declaration = true;
+    function _log(topic, message) {
+        if (config.verbose) {
+            gulp_util_1.log(gulp_util_1.colors.cyan(topic), message);
+        }
+    }
+    function printDiagnostic(diag, onError) {
+        var lineAndCh = diag.file.getLineAndCharacterOfPosition(diag.start), message;
+        if (!config.json) {
+            message = utils.strings.format('{0}({1},{2}): {3}', diag.file.fileName, lineAndCh.line + 1, lineAndCh.character + 1, ts.flattenDiagnosticMessageText(diag.messageText, '\n'));
+        }
+        else {
+            message = JSON.stringify({
+                filename: diag.file.fileName,
+                offset: diag.start,
+                length: diag.length,
+                message: ts.flattenDiagnosticMessageText(diag.messageText, '\n')
+            });
+        }
+        onError(message);
+    }
+    function file(file) {
+        // support gulp-sourcemaps
+        if (file.sourceMap) {
+            emitSourceMapsInStream = false;
+        }
+        if (!file.contents) {
+            host.removeScriptSnapshot(file.path);
+        }
+        else {
+            host.addScriptSnapshot(file.path, new VinylScriptSnapshot(file));
+        }
+    }
+    function baseFor(snapshot) {
+        if (snapshot instanceof VinylScriptSnapshot) {
+            return compilerOptions.outDir || snapshot.getBase();
+        }
+        else {
+            return '';
+        }
+    }
+    function isExternalModule(sourceFile) {
+        return sourceFile.externalModuleIndicator
+            || /declare\s+module\s+('|")(.+)\1/.test(sourceFile.getText());
+    }
+    function build(out, onError, token) {
+        if (token === void 0) { token = CancellationToken.None; }
+        function checkSyntaxSoon(fileName) {
+            return new Promise(function (resolve) {
+                process.nextTick(function () {
+                    resolve(service.getSyntacticDiagnostics(fileName));
+                });
+            });
+        }
+        function checkSemanticsSoon(fileName) {
+            return new Promise(function (resolve) {
+                process.nextTick(function () {
+                    resolve(service.getSemanticDiagnostics(fileName));
+                });
+            });
+        }
+        function emitSoon(fileName) {
+            return new Promise(function (resolve) {
+                process.nextTick(function () {
+                    if (/\.d\.ts$/.test(fileName)) {
+                        // if it's already a d.ts file just emit it signature
+                        var snapshot = host.getScriptSnapshot(fileName);
+                        var signature_1 = crypto.createHash('md5')
+                            .update(snapshot.getText(0, snapshot.getLength()))
+                            .digest('base64');
+                        return resolve({
+                            fileName: fileName,
+                            signature: signature_1,
+                            files: []
+                        });
+                    }
+                    var output = service.getEmitOutput(fileName);
+                    var files = [];
+                    var signature;
+                    for (var _i = 0, _a = output.outputFiles; _i < _a.length; _i++) {
+                        var file_1 = _a[_i];
+                        if (!emitSourceMapsInStream && /\.js\.map$/.test(file_1.name)) {
+                            continue;
+                        }
+                        if (/\.d\.ts$/.test(file_1.name)) {
+                            signature = crypto.createHash('md5')
+                                .update(file_1.text)
+                                .digest('base64');
+                            if (!userWantsDeclarations) {
+                                // don't leak .d.ts files if users don't want them
+                                continue;
+                            }
+                        }
+                        var vinyl = new Vinyl({
+                            path: file_1.name,
+                            contents: new Buffer(file_1.text),
+                            base: !config._emitWithoutBasePath && baseFor(host.getScriptSnapshot(fileName))
+                        });
+                        if (!emitSourceMapsInStream && /\.js$/.test(file_1.name)) {
+                            var sourcemapFile = output.outputFiles.filter(function (f) { return /\.js\.map$/.test(f.name); })[0];
+                            if (sourcemapFile) {
+                                var extname = path.extname(vinyl.relative);
+                                var basename = path.basename(vinyl.relative, extname);
+                                var dirname = path.dirname(vinyl.relative);
+                                var tsname = (dirname === '.' ? '' : dirname + '/') + basename + '.ts';
+                                var sourceMap = JSON.parse(sourcemapFile.text);
+                                sourceMap.sources[0] = tsname.replace(/\\/g, '/');
+                                vinyl.sourceMap = sourceMap;
+                            }
+                        }
+                        files.push(vinyl);
+                    }
+                    resolve({
+                        fileName: fileName,
+                        signature: signature,
+                        files: files
+                    });
+                });
+            });
+        }
+        var newErrors = Object.create(null);
+        var t1 = Date.now();
+        var toBeEmitted = [];
+        var toBeCheckedSyntactically = [];
+        var toBeCheckedSemantically = [];
+        var filesWithChangedSignature = [];
+        var dependentFiles = [];
+        var newLastBuildVersion = new Map();
+        for (var _i = 0, _a = host.getScriptFileNames(); _i < _a.length; _i++) {
+            var fileName = _a[_i];
+            if (lastBuildVersion[fileName] !== host.getScriptVersion(fileName)) {
+                toBeEmitted.push(fileName);
+                toBeCheckedSyntactically.push(fileName);
+                toBeCheckedSemantically.push(fileName);
+            }
+        }
+        return new Promise(function (resolve) {
+            var semanticCheckInfo = new Map();
+            var seenAsDependentFile = new Set();
+            function workOnNext() {
+                var promise;
+                var fileName;
+                // someone told us to stop this
+                if (token.isCancellationRequested()) {
+                    _log('[CANCEL]', '>>This compile run was cancelled<<');
+                    newLastBuildVersion.clear();
+                    resolve();
+                    return;
+                }
+                else if (toBeEmitted.length) {
+                    fileName = toBeEmitted.pop();
+                    promise = emitSoon(fileName).then(function (value) {
+                        for (var _i = 0, _a = value.files; _i < _a.length; _i++) {
+                            var file_2 = _a[_i];
+                            _log('[emit code]', file_2.path);
+                            out(file_2);
+                        }
+                        // remember when this was build
+                        newLastBuildVersion.set(fileName, host.getScriptVersion(fileName));
+                        // remeber the signature
+                        if (value.signature && lastDtsHash[fileName] !== value.signature) {
+                            lastDtsHash[fileName] = value.signature;
+                            filesWithChangedSignature.push(fileName);
+                        }
+                    });
+                }
+                else if (toBeCheckedSyntactically.length) {
+                    fileName = toBeCheckedSyntactically.pop();
+                    _log('[check syntax]', fileName);
+                    promise = checkSyntaxSoon(fileName).then(function (diagnostics) {
+                        delete oldErrors[fileName];
+                        if (diagnostics.length > 0) {
+                            diagnostics.forEach(function (d) { return printDiagnostic(d, onError); });
+                            newErrors[fileName] = diagnostics;
+                            // stop the world when there are syntax errors
+                            toBeCheckedSyntactically.length = 0;
+                            toBeCheckedSemantically.length = 0;
+                            filesWithChangedSignature.length = 0;
+                        }
+                    });
+                }
+                else if (toBeCheckedSemantically.length) {
+                    fileName = toBeCheckedSemantically.pop();
+                    while (fileName && semanticCheckInfo.has(fileName)) {
+                        fileName = toBeCheckedSemantically.pop();
+                    }
+                    if (fileName) {
+                        _log('[check semantics]', fileName);
+                        promise = checkSemanticsSoon(fileName).then(function (diagnostics) {
+                            delete oldErrors[fileName];
+                            semanticCheckInfo.set(fileName, diagnostics.length);
+                            if (diagnostics.length > 0) {
+                                diagnostics.forEach(function (d) { return printDiagnostic(d, onError); });
+                                newErrors[fileName] = diagnostics;
+                            }
+                        });
+                    }
+                }
+                else if (filesWithChangedSignature.length) {
+                    while (filesWithChangedSignature.length) {
+                        var fileName_1 = filesWithChangedSignature.pop();
+                        if (!isExternalModule(service.getProgram().getSourceFile(fileName_1))) {
+                            _log('[check semantics*]', fileName_1 + ' is an internal module and it has changed shape -> check whatever hasn\'t been checked yet');
+                            toBeCheckedSemantically.push.apply(toBeCheckedSemantically, host.getScriptFileNames());
+                            filesWithChangedSignature.length = 0;
+                            dependentFiles.length = 0;
+                            break;
+                        }
+                        host.collectDependents(fileName_1, dependentFiles);
+                    }
+                }
+                else if (dependentFiles.length) {
+                    fileName = dependentFiles.pop();
+                    while (fileName && seenAsDependentFile.has(fileName)) {
+                        fileName = dependentFiles.pop();
+                    }
+                    if (fileName) {
+                        seenAsDependentFile.add(fileName);
+                        var value = semanticCheckInfo.get(fileName);
+                        if (value === 0) {
+                            // already validated successfully -> look at dependents next
+                            host.collectDependents(fileName, dependentFiles);
+                        }
+                        else if (typeof value === 'undefined') {
+                            // first validate -> look at dependents next
+                            dependentFiles.push(fileName);
+                            toBeCheckedSemantically.push(fileName);
+                        }
+                    }
+                }
+                else {
+                    resolve();
+                    return;
+                }
+                if (!promise) {
+                    promise = Promise.resolve();
+                }
+                promise.then(function () {
+                    // change to change
+                    process.nextTick(workOnNext);
+                }).catch(function (err) {
+                    console.error(err);
+                });
+            }
+            workOnNext();
+        }).then(function () {
+            // store the build versions to not rebuilt the next time
+            newLastBuildVersion.forEach(function (value, key) {
+                lastBuildVersion[key] = value;
+            });
+            // print old errors and keep them
+            utils.collections.forEach(oldErrors, function (entry) {
+                entry.value.forEach(function (diag) { return printDiagnostic(diag, onError); });
+                newErrors[entry.key] = entry.value;
+            });
+            oldErrors = newErrors;
+            // print stats
+            if (config.verbose) {
+                var headNow = process.memoryUsage().heapUsed, MB = 1024 * 1024;
+                gulp_util_1.log('[tsb]', 'time:', gulp_util_1.colors.yellow((Date.now() - t1) + 'ms'), 'mem:', gulp_util_1.colors.cyan(Math.ceil(headNow / MB) + 'MB'), gulp_util_1.colors.bgCyan('Δ' + Math.ceil((headNow - headUsed) / MB)));
+                headUsed = headNow;
+            }
+        });
+    }
+    return {
+        file: file,
+        build: build,
+        languageService: service
+    };
+}
+exports.createTypeScriptBuilder = createTypeScriptBuilder;
+var ScriptSnapshot = (function () {
+    function ScriptSnapshot(text, mtime) {
+        this._text = text;
+        this._mtime = mtime;
+    }
+    ScriptSnapshot.prototype.getVersion = function () {
+        return this._mtime.toUTCString();
+    };
+    ScriptSnapshot.prototype.getText = function (start, end) {
+        return this._text.substring(start, end);
+    };
+    ScriptSnapshot.prototype.getLength = function () {
+        return this._text.length;
+    };
+    ScriptSnapshot.prototype.getChangeRange = function (oldSnapshot) {
+        return null;
+    };
+    return ScriptSnapshot;
+}());
+var VinylScriptSnapshot = (function (_super) {
+    __extends(VinylScriptSnapshot, _super);
+    function VinylScriptSnapshot(file) {
+        var _this = _super.call(this, file.contents.toString(), file.stat.mtime) || this;
+        _this._base = file.base;
+        return _this;
+    }
+    VinylScriptSnapshot.prototype.getBase = function () {
+        return this._base;
+    };
+    return VinylScriptSnapshot;
+}(ScriptSnapshot));
+var LanguageServiceHost = (function () {
+    function LanguageServiceHost(settings, noFilesystemLookup) {
+        this._settings = settings;
+        this._noFilesystemLookup = noFilesystemLookup;
+        this._snapshots = Object.create(null);
+        this._projectVersion = 1;
+        this._dependencies = new utils.graph.Graph(function (s) { return s; });
+        this._dependenciesRecomputeList = [];
+        this._fileNameToDeclaredModule = Object.create(null);
+    }
+    LanguageServiceHost.prototype.log = function (s) {
+        // nothing
+    };
+    LanguageServiceHost.prototype.trace = function (s) {
+        // nothing
+    };
+    LanguageServiceHost.prototype.error = function (s) {
+        console.error(s);
+    };
+    LanguageServiceHost.prototype.getCompilationSettings = function () {
+        return this._settings;
+    };
+    LanguageServiceHost.prototype.getProjectVersion = function () {
+        return String(this._projectVersion);
+    };
+    LanguageServiceHost.prototype.getScriptFileNames = function () {
+        var result = [];
+        var libLocation = this.getDefaultLibLocation();
+        for (var fileName in this._snapshots) {
+            if (/\.tsx?/i.test(path.extname(fileName))
+                && normalize(path.dirname(fileName)) !== libLocation) {
+                // only ts-files and not lib.d.ts-like files
+                result.push(fileName);
+            }
+        }
+        return result;
+    };
+    LanguageServiceHost.prototype.getScriptVersion = function (filename) {
+        filename = normalize(filename);
+        return this._snapshots[filename].getVersion();
+    };
+    LanguageServiceHost.prototype.getScriptSnapshot = function (filename) {
+        filename = normalize(filename);
+        var result = this._snapshots[filename];
+        if (!result && !this._noFilesystemLookup) {
+            try {
+                result = new VinylScriptSnapshot(new Vinyl({
+                    path: filename,
+                    contents: fs_1.readFileSync(filename),
+                    base: this._settings.outDir,
+                    stat: fs_1.statSync(filename)
+                }));
+                this.addScriptSnapshot(filename, result);
+            }
+            catch (e) {
+            }
+        }
+        return result;
+    };
+    LanguageServiceHost.prototype.addScriptSnapshot = function (filename, snapshot) {
+        this._projectVersion++;
+        filename = normalize(filename);
+        var old = this._snapshots[filename];
+        if (!old || old.getVersion() !== snapshot.getVersion()) {
+            this._dependenciesRecomputeList.push(filename);
+            var node = this._dependencies.lookup(filename);
+            if (node) {
+                node.outgoing = Object.create(null);
+            }
+            // (cheap) check for declare module
+            LanguageServiceHost._declareModule.lastIndex = 0;
+            var match = void 0;
+            while ((match = LanguageServiceHost._declareModule.exec(snapshot.getText(0, snapshot.getLength())))) {
+                var declaredModules = this._fileNameToDeclaredModule[filename];
+                if (!declaredModules) {
+                    this._fileNameToDeclaredModule[filename] = declaredModules = [];
+                }
+                declaredModules.push(match[2]);
+            }
+        }
+        this._snapshots[filename] = snapshot;
+        return old;
+    };
+    LanguageServiceHost.prototype.removeScriptSnapshot = function (filename) {
+        this._projectVersion++;
+        filename = normalize(filename);
+        delete this._fileNameToDeclaredModule[filename];
+        return delete this._snapshots[filename];
+    };
+    LanguageServiceHost.prototype.getLocalizedDiagnosticMessages = function () {
+        return null;
+    };
+    LanguageServiceHost.prototype.getCancellationToken = function () {
+        return {
+            isCancellationRequested: function () { return false; },
+            throwIfCancellationRequested: function () {
+                // Do nothing.isCancellationRequested is always
+                // false so this method never throws
+            }
+        };
+    };
+    LanguageServiceHost.prototype.getCurrentDirectory = function () {
+        return process.cwd();
+    };
+    LanguageServiceHost.prototype.getDefaultLibFileName = function (options) {
+        return normalize(path.join(this.getDefaultLibLocation(), ts.getDefaultLibFileName(options)));
+    };
+    LanguageServiceHost.prototype.getDefaultLibLocation = function () {
+        var typescriptInstall = require.resolve('typescript');
+        return normalize(path.dirname(typescriptInstall));
+    };
+    // ---- dependency management
+    LanguageServiceHost.prototype.collectDependents = function (filename, target) {
+        while (this._dependenciesRecomputeList.length) {
+            this._processFile(this._dependenciesRecomputeList.pop());
+        }
+        filename = normalize(filename);
+        var node = this._dependencies.lookup(filename);
+        if (node) {
+            utils.collections.forEach(node.incoming, function (entry) { return target.push(entry.key); });
+        }
+    };
+    LanguageServiceHost.prototype._processFile = function (filename) {
+        var _this = this;
+        if (filename.match(/.*\.d\.ts$/)) {
+            return;
+        }
+        filename = normalize(filename);
+        var snapshot = this.getScriptSnapshot(filename), info = ts.preProcessFile(snapshot.getText(0, snapshot.getLength()), true);
+        // (1) ///-references
+        info.referencedFiles.forEach(function (ref) {
+            var resolvedPath = path.resolve(path.dirname(filename), ref.fileName), normalizedPath = normalize(resolvedPath);
+            _this._dependencies.inertEdge(filename, normalizedPath);
+        });
+        // (2) import-require statements
+        info.importedFiles.forEach(function (ref) {
+            var stopDirname = normalize(_this.getCurrentDirectory()), dirname = filename, found = false;
+            while (!found && dirname.indexOf(stopDirname) === 0) {
+                dirname = path.dirname(dirname);
+                var resolvedPath = path.resolve(dirname, ref.fileName), normalizedPath = normalize(resolvedPath);
+                if (_this.getScriptSnapshot(normalizedPath + '.ts')) {
+                    _this._dependencies.inertEdge(filename, normalizedPath + '.ts');
+                    found = true;
+                }
+                else if (_this.getScriptSnapshot(normalizedPath + '.d.ts')) {
+                    _this._dependencies.inertEdge(filename, normalizedPath + '.d.ts');
+                    found = true;
+                }
+            }
+            if (!found) {
+                for (var key in _this._fileNameToDeclaredModule) {
+                    if (_this._fileNameToDeclaredModule[key] && ~_this._fileNameToDeclaredModule[key].indexOf(ref.fileName)) {
+                        _this._dependencies.inertEdge(filename, key);
+                    }
+                }
+            }
+        });
+    };
+    return LanguageServiceHost;
+}());
+LanguageServiceHost._declareModule = /declare\s+module\s+('|")(.+)\1/g;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,59 @@
+/// <reference path="../node_modules/typescript/lib/lib.es6.d.ts"/>
+'use strict';
+var through = require("through");
+var builder = require("./builder");
+var ts = require("typescript");
+var fs_1 = require("fs");
+var path_1 = require("path");
+// We actually only want to read the tsconfig.json file. So all methods
+// to read the FS are 'empty' implementations.
+var _parseConfigHost = {
+    useCaseSensitiveFileNames: false,
+    fileExists: function (fileName) {
+        return fs_1.existsSync(fileName);
+    },
+    readDirectory: function (rootDir, extensions, excludes, includes) {
+        return []; // don't want to find files!
+    },
+    readFile: function (fileName) {
+        return fs_1.readFileSync(fileName, 'utf-8');
+    },
+};
+function create(configOrName, verbose, json, onError) {
+    var options = ts.getDefaultCompilerOptions();
+    var config = { json: json, verbose: verbose, noFilesystemLookup: false };
+    if (typeof configOrName === 'string') {
+        var parsed = ts.readConfigFile(configOrName, _parseConfigHost.readFile);
+        options = ts.parseJsonConfigFileContent(parsed.config, _parseConfigHost, path_1.dirname(configOrName)).options;
+        if (parsed.error) {
+            console.error(parsed.error);
+            return function () { return null; };
+        }
+    }
+    else {
+        options = ts.parseJsonConfigFileContent({ compilerOptions: configOrName }, _parseConfigHost, './').options;
+        Object.assign(config, configOrName);
+    }
+    if (!onError) {
+        onError = function (err) { return console.log(JSON.stringify(err, null, 4)); };
+    }
+    var _builder = builder.createTypeScriptBuilder(config, options);
+    function createStream(token) {
+        return through(function (file) {
+            // give the file to the compiler
+            if (file.isStream()) {
+                this.emit('error', 'no support for streams');
+                return;
+            }
+            _builder.file(file);
+        }, function () {
+            var _this = this;
+            // start the compilation process
+            _builder.build(function (file) { return _this.queue(file); }, onError, token).then(function () { return _this.queue(null); });
+        });
+    }
+    var result = function (token) { return createStream(token); };
+    Object.defineProperty(result, 'program', { get: function () { return _builder.languageService.getProgram(); } });
+    return result;
+}
+exports.create = create;

--- a/lib/tests/index.test.js
+++ b/lib/tests/index.test.js
@@ -1,0 +1,23 @@
+'use strict';
+var index = require("../index");
+var assert = require("assert");
+describe('options - test that', function () {
+    it('does not change the config object', function () {
+        var config = {
+            json: true,
+            verbose: true,
+            noFilesystemLookup: true
+        };
+        Object.freeze(config);
+        index.create(config);
+        assert.equal(Object.keys(config).length, 3);
+    });
+    it('keeps allowJs', function () {
+        var compiler = index.create({ allowJs: true });
+        assert.equal(compiler.program.getCompilerOptions().allowJs, true);
+        compiler = index.create({ allowJs: false });
+        assert.equal(compiler.program.getCompilerOptions().allowJs, false);
+        compiler = index.create({});
+        assert.equal(compiler.program.getCompilerOptions().allowJs, undefined);
+    });
+});

--- a/lib/tests/utils.test.js
+++ b/lib/tests/utils.test.js
@@ -1,0 +1,54 @@
+'use strict';
+var utils = require("../utils");
+var assert = require("assert");
+describe('graph - test that', function () {
+    var graph;
+    beforeEach(function () {
+        graph = new utils.graph.Graph(function (s) { return s; });
+    });
+    it('cannot be traversed when empty', function () {
+        graph.traverse('foo', true, function () { return assert.ok(false); });
+        graph.traverse('foo', false, function () { return assert.ok(false); });
+        assert.ok(true);
+    });
+    it('is possible to lookup nodes that don\'t exist', function () {
+        assert.deepEqual(graph.lookup('ddd'), null);
+    });
+    it('inserts nodes when not there yet', function () {
+        assert.deepEqual(graph.lookup('ddd'), null);
+        assert.deepEqual(graph.lookupOrInsertNode('ddd').data, 'ddd');
+        assert.deepEqual(graph.lookup('ddd').data, 'ddd');
+    });
+    it('can remove nodes', function () {
+        assert.deepEqual(graph.lookup('ddd'), null);
+        assert.deepEqual(graph.lookupOrInsertNode('ddd').data, 'ddd');
+        graph.removeNode('ddd');
+        assert.deepEqual(graph.lookup('ddd'), null);
+    });
+    it('traverse from leaf', function () {
+        graph.inertEdge('foo', 'bar');
+        graph.traverse('bar', true, function (node) { return assert.equal(node, 'bar'); });
+        var items = ['bar', 'foo'];
+        graph.traverse('bar', false, function (node) { return assert.equal(node, items.shift()); });
+    });
+    it('traverse from center', function () {
+        graph.inertEdge('1', '3');
+        graph.inertEdge('2', '3');
+        graph.inertEdge('3', '4');
+        graph.inertEdge('3', '5');
+        var items = ['3', '4', '5'];
+        graph.traverse('3', true, function (node) { return assert.equal(node, items.shift()); });
+        var items = ['3', '1', '2'];
+        graph.traverse('3', false, function (node) { return assert.equal(node, items.shift()); });
+    });
+    it('traverse a chain', function () {
+        graph.inertEdge('1', '2');
+        graph.inertEdge('2', '3');
+        graph.inertEdge('3', '4');
+        graph.inertEdge('4', '5');
+        var items = ['1', '2', '3', '4', '5'];
+        graph.traverse('1', true, function (node) { return assert.equal(node, items.shift()); });
+        var items = ['1', '2', '3', '4', '5'].reverse();
+        graph.traverse('5', false, function (node) { return assert.equal(node, items.shift()); });
+    });
+});

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,122 @@
+'use strict';
+var collections;
+(function (collections) {
+    var hasOwnProperty = Object.prototype.hasOwnProperty;
+    function lookup(collection, key) {
+        if (hasOwnProperty.call(collection, key)) {
+            return collection[key];
+        }
+        return null;
+    }
+    collections.lookup = lookup;
+    function insert(collection, key, value) {
+        collection[key] = value;
+    }
+    collections.insert = insert;
+    function lookupOrInsert(collection, key, value) {
+        if (hasOwnProperty.call(collection, key)) {
+            return collection[key];
+        }
+        else {
+            collection[key] = value;
+            return value;
+        }
+    }
+    collections.lookupOrInsert = lookupOrInsert;
+    function forEach(collection, callback) {
+        for (var key in collection) {
+            if (hasOwnProperty.call(collection, key)) {
+                callback({
+                    key: key,
+                    value: collection[key]
+                });
+            }
+        }
+    }
+    collections.forEach = forEach;
+    function contains(collection, key) {
+        return hasOwnProperty.call(collection, key);
+    }
+    collections.contains = contains;
+})(collections = exports.collections || (exports.collections = {}));
+var strings;
+(function (strings) {
+    /**
+     * The empty string. The one and only.
+     */
+    strings.empty = '';
+    strings.eolUnix = '\r\n';
+    function format(value) {
+        var rest = [];
+        for (var _i = 1; _i < arguments.length; _i++) {
+            rest[_i - 1] = arguments[_i];
+        }
+        return value.replace(/({\d+})/g, function (match) {
+            var index = match.substring(1, match.length - 1);
+            return rest[index] || match;
+        });
+    }
+    strings.format = format;
+})(strings = exports.strings || (exports.strings = {}));
+var graph;
+(function (graph) {
+    function newNode(data) {
+        return {
+            data: data,
+            incoming: {},
+            outgoing: {}
+        };
+    }
+    graph.newNode = newNode;
+    var Graph = (function () {
+        function Graph(_hashFn) {
+            this._hashFn = _hashFn;
+            this._nodes = {};
+            // empty
+        }
+        Graph.prototype.traverse = function (start, inwards, callback) {
+            var startNode = this.lookup(start);
+            if (!startNode) {
+                return;
+            }
+            this._traverse(startNode, inwards, {}, callback);
+        };
+        Graph.prototype._traverse = function (node, inwards, seen, callback) {
+            var _this = this;
+            var key = this._hashFn(node.data);
+            if (collections.contains(seen, key)) {
+                return;
+            }
+            seen[key] = true;
+            callback(node.data);
+            var nodes = inwards ? node.outgoing : node.incoming;
+            collections.forEach(nodes, function (entry) { return _this._traverse(entry.value, inwards, seen, callback); });
+        };
+        Graph.prototype.inertEdge = function (from, to) {
+            var fromNode = this.lookupOrInsertNode(from), toNode = this.lookupOrInsertNode(to);
+            fromNode.outgoing[this._hashFn(to)] = toNode;
+            toNode.incoming[this._hashFn(from)] = fromNode;
+        };
+        Graph.prototype.removeNode = function (data) {
+            var key = this._hashFn(data);
+            delete this._nodes[key];
+            collections.forEach(this._nodes, function (entry) {
+                delete entry.value.outgoing[key];
+                delete entry.value.incoming[key];
+            });
+        };
+        Graph.prototype.lookupOrInsertNode = function (data) {
+            var key = this._hashFn(data), node = collections.lookup(this._nodes, key);
+            if (!node) {
+                node = newNode(data);
+                this._nodes[key] = node;
+            }
+            return node;
+        };
+        Graph.prototype.lookup = function (data) {
+            return collections.lookup(this._nodes, this._hashFn(data));
+        };
+        return Graph;
+    }());
+    graph.Graph = Graph;
+})(graph = exports.graph || (exports.graph = {}));

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "2.0.3",
   "author": "Johannes Rieken <johannes.rieken@gmail.com>",
   "description": "A gulp plugin for very fast TypeScript compilation.",
-  "main": "./lib/index",
+  "main": "./lib",
   "license": "MIT",
   "scripts": {
-    "test": "mocha lib/tests",
-    "prepublish": "tsc && mocha lib/tests",
-    "compile": "tsc"
+    "test": "gulp test",
+    "prepublish": "gulp lkg",
+    "compile": "gulp build"
   },
   "repository": {
     "type": "git",
@@ -26,15 +26,18 @@
     "vinyl": "^0.4.3"
   },
   "devDependencies": {
-    "gulp": "^3.8.10",
-    "mocha": "*",
-    "typescript": "^2.0.3",
-    "@types/node": "*",
     "@types/chalk": "*",
     "@types/gulp-util": "*",
     "@types/mocha": "*",
+    "@types/node": "*",
     "@types/through": "*",
-    "@types/vinyl": "*"
+    "@types/vinyl": "*",
+    "del": "^2.2.2",
+    "gulp": "^3.8.10",
+    "gulp-mocha": "^3.0.1",
+    "mocha": "*",
+    "run-sequence": "^1.2.2",
+    "typescript": "^2.0.3"
   },
   "peerDependencies": {
     "typescript": "^2.0.10"


### PR DESCRIPTION
Breaking down #45 into smaller chunks. 

This PR contains the following changes:
* Update the gulp build to support an LKG ("last known good") build of `gulp-tsb`.
* Update the gulp build to compile an "interim build" of `gulp-tsb` with the LKG build, and use the "interim build" to compile a "latest build" of `gulp-tsb` as a simple build verification step.
* Use `gulp-mocha` to run tests in watch mode.
* Update the `"scripts"` section of package.json to use gulp for the `test`, `compile`, and `prepublish` scripts.
* Include the `lib` output directory in git to allow npm installation of an unpublished build.

Minor project structure changes:
* `lib/` stores the LKG build and is now checked in.
* `tmp/` stores an "interim build" of `gulp-tsb` and is excluded from git and npm.
* `out/` stores a "latest build" of `gulp-tsb` and is excluded from git and npm.

New gulp tasks:
* `gulp clean` - Cleans the `tmp/` and `out/` directories.
* `gulp test` - Builds `gulp-tsb` and runs mocha.
* `gulp lkg` - Copy the "latest build" to `lib/` as the new "last known good" build.
