### PR TITLE
Fix for TS 2.4 Module Resolution Changes

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -436,9 +436,6 @@ var LanguageServiceHost = (function () {
     LanguageServiceHost.prototype.getCurrentDirectory = function () {
         return process.cwd();
     };
-    LanguageServiceHost.prototype.directoryExists = function (directoryName) {
-        return fs_1.existsSync(directoryName);
-    };
     LanguageServiceHost.prototype.fileExists = function (fileName) {
         return fs_1.existsSync(fileName);
     };

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,9 +1,15 @@
 'use strict';
-var __extends = (this && this.__extends) || function (d, b) {
-    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
-    function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-};
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
 var fs_1 = require("fs");
 var path = require("path");
 var crypto = require("crypto");
@@ -380,6 +386,7 @@ var LanguageServiceHost = (function () {
                 this.addScriptSnapshot(filename, result);
             }
             catch (e) {
+                // ignore
             }
         }
         return result;
@@ -428,6 +435,15 @@ var LanguageServiceHost = (function () {
     };
     LanguageServiceHost.prototype.getCurrentDirectory = function () {
         return process.cwd();
+    };
+    LanguageServiceHost.prototype.directoryExists = function (directoryName) {
+        return fs_1.existsSync(directoryName);
+    };
+    LanguageServiceHost.prototype.fileExists = function (fileName) {
+        return fs_1.existsSync(fileName);
+    };
+    LanguageServiceHost.prototype.readFile = function (fileName) {
+        return fs_1.readFileSync(fileName, 'utf8');
     };
     LanguageServiceHost.prototype.getDefaultLibFileName = function (options) {
         return normalize(path.join(this.getDefaultLibLocation(), ts.getDefaultLibFileName(options)));
@@ -483,6 +499,6 @@ var LanguageServiceHost = (function () {
             }
         });
     };
+    LanguageServiceHost._declareModule = /declare\s+module\s+('|")(.+)\1/g;
     return LanguageServiceHost;
 }());
-LanguageServiceHost._declareModule = /declare\s+module\s+('|")(.+)\1/g;

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -437,10 +437,10 @@ var LanguageServiceHost = (function () {
         return process.cwd();
     };
     LanguageServiceHost.prototype.fileExists = function (fileName) {
-        return fs_1.existsSync(fileName);
+        return !this._noFilesystemLookup && fs_1.existsSync(fileName);
     };
     LanguageServiceHost.prototype.readFile = function (fileName) {
-        return fs_1.readFileSync(fileName, 'utf8');
+        return this._noFilesystemLookup ? '' : fs_1.readFileSync(fileName, 'utf8');
     };
     LanguageServiceHost.prototype.getDefaultLibFileName = function (options) {
         return normalize(path.join(this.getDefaultLibLocation(), ts.getDefaultLibFileName(options)));

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 /// <reference path="../node_modules/typescript/lib/lib.es6.d.ts"/>
 'use strict';
+Object.defineProperty(exports, "__esModule", { value: true });
 var through = require("through");
 var builder = require("./builder");
 var ts = require("typescript");

--- a/lib/tests/index.test.js
+++ b/lib/tests/index.test.js
@@ -1,4 +1,5 @@
 'use strict';
+Object.defineProperty(exports, "__esModule", { value: true });
 var index = require("../index");
 var assert = require("assert");
 describe('options - test that', function () {

--- a/lib/tests/utils.test.js
+++ b/lib/tests/utils.test.js
@@ -1,4 +1,5 @@
 'use strict';
+Object.defineProperty(exports, "__esModule", { value: true });
 var utils = require("../utils");
 var assert = require("assert");
 describe('graph - test that', function () {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 'use strict';
+Object.defineProperty(exports, "__esModule", { value: true });
 var collections;
 (function (collections) {
     var hasOwnProperty = Object.prototype.hasOwnProperty;

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -554,10 +554,6 @@ class LanguageServiceHost implements ts.LanguageServiceHost {
         return process.cwd();
     }
 
-    directoryExists(directoryName: string): boolean {
-        return existsSync(directoryName);
-    }
-
     fileExists(fileName: string): boolean {
         return existsSync(fileName);
     }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -555,11 +555,11 @@ class LanguageServiceHost implements ts.LanguageServiceHost {
     }
 
     fileExists(fileName: string): boolean {
-        return existsSync(fileName);
+        return !this._noFilesystemLookup && existsSync(fileName);
     }
 
     readFile(fileName: string): string {
-        return readFileSync(fileName, 'utf8');
+        return this._noFilesystemLookup ? '' : readFileSync(fileName, 'utf8');
     }
 
     getDefaultLibFileName(options: ts.CompilerOptions): string {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import {Stats, statSync, readFileSync} from 'fs';
+import {Stats, statSync, readFileSync, existsSync} from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
 import * as utils from './utils';
@@ -552,6 +552,18 @@ class LanguageServiceHost implements ts.LanguageServiceHost {
 
     getCurrentDirectory(): string {
         return process.cwd();
+    }
+
+    directoryExists(directoryName: string): boolean {
+        return existsSync(directoryName);
+    }
+
+    fileExists(fileName: string): boolean {
+        return existsSync(fileName);
+    }
+
+    readFile(fileName: string): string {
+        return readFileSync(fileName, 'utf8');
     }
 
     getDefaultLibFileName(options: ts.CompilerOptions): string {


### PR DESCRIPTION
Fixes #62

**Bug**
TS 2.4 changes the builder logic, which blocks building vscode using gulp-tsb:  Microsoft/TypeScript#16772

**Fix**
Add missing methods as suggested by:  https://github.com/TypeStrong/ts-loader/pull/566/files