### PR TITLE
Fixes source map emit for use with gulp-sourcemaps

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,19 +1,10 @@
 'use strict';
-var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
-    return function (d, b) {
-        extendStatics(d, b);
-        function __() { this.constructor = d; }
-        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-    };
-})();
 Object.defineProperty(exports, "__esModule", { value: true });
 var fs_1 = require("fs");
 var path = require("path");
 var crypto = require("crypto");
 var utils = require("./utils");
+var os_1 = require("os");
 var gulp_util_1 = require("gulp-util");
 var ts = require("typescript");
 var Vinyl = require("vinyl");
@@ -26,7 +17,22 @@ var CancellationToken;
 function normalize(path) {
     return path.replace(/\\/g, '/');
 }
+function fixCompilerOptions(config, compilerOptions) {
+    // clean up compiler options that conflict with gulp
+    if (compilerOptions.inlineSourceMap)
+        compilerOptions.sourceMap = true;
+    delete compilerOptions.inlineSourceMap; // handled by gulp-sourcemaps
+    delete compilerOptions.inlineSources; // handled by gulp-sourcemaps
+    delete compilerOptions.sourceRoot; // incompatible with gulp-sourcemaps
+    delete compilerOptions.mapRoot; // incompatible with gulp-sourcemaps
+    delete compilerOptions.outDir; // always emit relative to source file
+    compilerOptions.declaration = true; // always emit declaration files
+    return compilerOptions;
+}
 function createTypeScriptBuilder(config, compilerOptions) {
+    // fix compiler options
+    var originalCompilerOptions = utils.collections.structuredClone(compilerOptions);
+    compilerOptions = fixCompilerOptions(config, utils.collections.structuredClone(compilerOptions));
     var host = new LanguageServiceHost(compilerOptions, config.noFilesystemLookup || false), service = ts.createLanguageService(host, ts.createDocumentRegistry()), lastBuildVersion = Object.create(null), lastDtsHash = Object.create(null), userWantsDeclarations = compilerOptions.declaration, oldErrors = Object.create(null), headUsed = process.memoryUsage().heapUsed, emitSourceMapsInStream = true;
     // always emit declaraction files
     host.getCompilationSettings().declaration = true;
@@ -59,15 +65,14 @@ function createTypeScriptBuilder(config, compilerOptions) {
             host.removeScriptSnapshot(file.path);
         }
         else {
-            host.addScriptSnapshot(file.path, new VinylScriptSnapshot(file));
+            host.addScriptSnapshot(file.path, new ScriptSnapshot(file));
         }
     }
-    function baseFor(snapshot) {
-        if (snapshot instanceof VinylScriptSnapshot) {
-            return compilerOptions.outDir || snapshot.getBase();
-        }
-        else {
-            return '';
+    function getNewLine() {
+        switch (compilerOptions.newLine) {
+            case ts.NewLineKind.CarriageReturnLineFeed: return "\r\n";
+            case ts.NewLineKind.LineFeed: return "\n";
+            default: return os_1.EOL;
         }
     }
     function isExternalModule(sourceFile) {
@@ -105,41 +110,111 @@ function createTypeScriptBuilder(config, compilerOptions) {
                             files: []
                         });
                     }
+                    var input = host.getScriptSnapshot(fileName);
                     var output = service.getEmitOutput(fileName);
                     var files = [];
                     var signature;
+                    var javaScriptFile;
+                    var declarationFile;
+                    var sourceMapFile;
                     for (var _i = 0, _a = output.outputFiles; _i < _a.length; _i++) {
                         var file_1 = _a[_i];
-                        if (!emitSourceMapsInStream && /\.js\.map$/.test(file_1.name)) {
-                            continue;
+                        // When gulp-sourcemaps writes out a sourceMap, it uses the path
+                        // information of the associated file. Specifically, it uses the base
+                        // directory and relative path of the file to make decisions on how to
+                        // write the "sources" and "sourceRoot" properties.
+                        //
+                        // To emit the correct paths, we need to have the output files emulate
+                        // a path local to the source location, not the expected output location.
+                        //
+                        // Since gulp.dest sets our output location for us, then all that matters
+                        // to gulp.dest is the relative path for each file. This means that we
+                        // should be able to safely treat output files as local to sources to
+                        // better support gulp-sourcemaps.
+                        var base = !config._emitWithoutBasePath ? input.getBase() : undefined;
+                        var relative = base && path.relative(base, file_1.name);
+                        var name_1 = relative ? path.resolve(base, relative) : file_1.name;
+                        var contents = new Buffer(file_1.text);
+                        var vinyl = new Vinyl({ path: name_1, base: base, contents: contents });
+                        if (/\.js$/.test(vinyl.path)) {
+                            javaScriptFile = vinyl;
                         }
-                        if (/\.d\.ts$/.test(file_1.name)) {
-                            signature = crypto.createHash('md5')
-                                .update(file_1.text)
-                                .digest('base64');
-                            if (!userWantsDeclarations) {
-                                // don't leak .d.ts files if users don't want them
-                                continue;
+                        else if (/\.js\.map$/.test(vinyl.path)) {
+                            sourceMapFile = vinyl;
+                        }
+                        else if (/\.d\.ts$/.test(vinyl.path)) {
+                            declarationFile = vinyl;
+                        }
+                    }
+                    if (javaScriptFile) {
+                        // gulp-sourcemaps will add an appropriate sourceMappingURL comment, so we need to remove the
+                        // one that TypeScript generates.
+                        var sourceMappingURLPattern = /(\r\n?|\n)?\/\/# sourceMappingURL=[^\r\n]+(?=[\r\n\s]*$)/;
+                        var contents = javaScriptFile.contents.toString();
+                        javaScriptFile.contents = new Buffer(contents.replace(sourceMappingURLPattern, ""));
+                        files.push(javaScriptFile);
+                    }
+                    if (declarationFile) {
+                        signature = crypto.createHash('md5')
+                            .update(declarationFile.contents)
+                            .digest('base64');
+                        if (originalCompilerOptions.declaration) {
+                            // don't leak .d.ts files if users don't want them
+                            files.push(declarationFile);
+                        }
+                    }
+                    if (sourceMapFile) {
+                        // adjust the source map to be relative to the source directory.
+                        var sourceMap = JSON.parse(sourceMapFile.contents.toString());
+                        var sourceRoot_1 = sourceMap.sourceRoot;
+                        var sources = sourceMap.sources.map(function (source) { return path.resolve(sourceMapFile.base, source); });
+                        var destPath_1 = path.resolve(config.base, originalCompilerOptions.outDir || ".");
+                        // update sourceRoot to be relative from the expected destination path
+                        sourceRoot_1 = emitSourceMapsInStream ? originalCompilerOptions.sourceRoot : sourceRoot_1;
+                        sourceMap.sourceRoot = sourceRoot_1 ? normalize(path.relative(destPath_1, sourceRoot_1)) : undefined;
+                        if (emitSourceMapsInStream) {
+                            // update sourcesContent
+                            if (originalCompilerOptions.inlineSources) {
+                                sourceMap.sourcesContent = sources.map(function (source) {
+                                    var snapshot = host.getScriptSnapshot(source) || input;
+                                    var vinyl = snapshot && snapshot.getFile();
+                                    return vinyl
+                                        ? vinyl.contents.toString("utf8")
+                                        : ts.sys.readFile(source);
+                                });
                             }
-                        }
-                        var vinyl = new Vinyl({
-                            path: file_1.name,
-                            contents: new Buffer(file_1.text),
-                            base: !config._emitWithoutBasePath && baseFor(host.getScriptSnapshot(fileName))
-                        });
-                        if (!emitSourceMapsInStream && /\.js$/.test(file_1.name)) {
-                            var sourcemapFile = output.outputFiles.filter(function (f) { return /\.js\.map$/.test(f.name); })[0];
-                            if (sourcemapFile) {
-                                var extname = path.extname(vinyl.relative);
-                                var basename = path.basename(vinyl.relative, extname);
-                                var dirname = path.dirname(vinyl.relative);
-                                var tsname = (dirname === '.' ? '' : dirname + '/') + basename + '.ts';
-                                var sourceMap = JSON.parse(sourcemapFile.text);
-                                sourceMap.sources[0] = tsname.replace(/\\/g, '/');
-                                vinyl.sourceMap = sourceMap;
+                            // make all sources relative to the sourceRoot or destPath
+                            sourceMap.sources = sources.map(function (source) {
+                                source = path.resolve(sourceMapFile.base, source);
+                                source = path.relative(sourceRoot_1 || destPath_1, source);
+                                source = normalize(source);
+                                return source;
+                            });
+                            // update the contents for the sourcemap file
+                            sourceMapFile.contents = new Buffer(JSON.stringify(sourceMap));
+                            var newLine = getNewLine();
+                            var contents = javaScriptFile.contents.toString();
+                            if (originalCompilerOptions.inlineSourceMap) {
+                                // restore the sourcemap as an inline source map in the javaScript file.
+                                contents += newLine + "//# sourceMappingURL=data:application/json;charset=utf8;base64," + sourceMapFile.contents.toString("base64") + newLine;
                             }
+                            else {
+                                contents += newLine + "//# sourceMappingURL=" + normalize(path.relative(path.dirname(javaScriptFile.path), sourceMapFile.path)) + newLine;
+                                files.push(sourceMapFile);
+                            }
+                            javaScriptFile.contents = new Buffer(contents);
                         }
-                        files.push(vinyl);
+                        else {
+                            // sourcesContent is handled by gulp-sourcemaps
+                            sourceMap.sourcesContent = undefined;
+                            // make all of the sources in the source map relative paths
+                            sourceMap.sources = sources.map(function (source) {
+                                var snapshot = host.getScriptSnapshot(source) || input;
+                                var vinyl = snapshot && snapshot.getFile();
+                                return vinyl ? normalize(vinyl.relative) : source;
+                            });
+                            javaScriptFile.sourceMap = sourceMap;
+                        }
                     }
                     resolve({
                         fileName: fileName,
@@ -300,10 +375,11 @@ function createTypeScriptBuilder(config, compilerOptions) {
     };
 }
 exports.createTypeScriptBuilder = createTypeScriptBuilder;
-var ScriptSnapshot = (function () {
-    function ScriptSnapshot(text, mtime) {
-        this._text = text;
-        this._mtime = mtime;
+var ScriptSnapshot = /** @class */ (function () {
+    function ScriptSnapshot(file) {
+        this._file = file;
+        this._text = file.contents.toString("utf8");
+        this._mtime = file.stat.mtime;
     }
     ScriptSnapshot.prototype.getVersion = function () {
         return this._mtime.toUTCString();
@@ -317,21 +393,15 @@ var ScriptSnapshot = (function () {
     ScriptSnapshot.prototype.getChangeRange = function (oldSnapshot) {
         return null;
     };
+    ScriptSnapshot.prototype.getFile = function () {
+        return this._file;
+    };
+    ScriptSnapshot.prototype.getBase = function () {
+        return this._file.base;
+    };
     return ScriptSnapshot;
 }());
-var VinylScriptSnapshot = (function (_super) {
-    __extends(VinylScriptSnapshot, _super);
-    function VinylScriptSnapshot(file) {
-        var _this = _super.call(this, file.contents.toString(), file.stat.mtime) || this;
-        _this._base = file.base;
-        return _this;
-    }
-    VinylScriptSnapshot.prototype.getBase = function () {
-        return this._base;
-    };
-    return VinylScriptSnapshot;
-}(ScriptSnapshot));
-var LanguageServiceHost = (function () {
+var LanguageServiceHost = /** @class */ (function () {
     function LanguageServiceHost(settings, noFilesystemLookup) {
         this._settings = settings;
         this._noFilesystemLookup = noFilesystemLookup;
@@ -377,7 +447,7 @@ var LanguageServiceHost = (function () {
         var result = this._snapshots[filename];
         if (!result && !this._noFilesystemLookup) {
             try {
-                result = new VinylScriptSnapshot(new Vinyl({
+                result = new ScriptSnapshot(new Vinyl({
                     path: filename,
                     contents: fs_1.readFileSync(filename),
                     base: this._settings.outDir,

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,11 +25,12 @@ function create(configOrName, verbose, json, onError) {
     var config = { json: json, verbose: verbose, noFilesystemLookup: false };
     if (typeof configOrName === 'string') {
         var parsed = ts.readConfigFile(configOrName, _parseConfigHost.readFile);
-        options = ts.parseJsonConfigFileContent(parsed.config, _parseConfigHost, path_1.dirname(configOrName)).options;
         if (parsed.error) {
             console.error(parsed.error);
             return function () { return null; };
         }
+        options = ts.parseJsonConfigFileContent(parsed.config, _parseConfigHost, path_1.dirname(configOrName), undefined, configOrName).options;
+        config.base = path_1.resolve(path_1.dirname(configOrName));
     }
     else {
         options = ts.parseJsonConfigFileContent({ compilerOptions: configOrName }, _parseConfigHost, './').options;
@@ -38,6 +39,8 @@ function create(configOrName, verbose, json, onError) {
     if (!onError) {
         onError = function (err) { return console.log(JSON.stringify(err, null, 4)); };
     }
+    if (!config.base)
+        config.base = process.cwd();
     var _builder = builder.createTypeScriptBuilder(config, options);
     function createStream(token) {
         return through(function (file) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,6 +39,29 @@ var collections;
         return hasOwnProperty.call(collection, key);
     }
     collections.contains = contains;
+    function structuredClone(value) {
+        return structuredCloneRecursive(value, new Map());
+    }
+    collections.structuredClone = structuredClone;
+    function structuredCloneRecursive(value, objects) {
+        if (value === undefined)
+            return undefined;
+        if (value === null)
+            return null;
+        if (typeof value !== "object")
+            return value;
+        var clone = objects.get(value);
+        if (clone === undefined) {
+            clone = Array.isArray(value) ? Array(value.length) : {};
+            objects.set(value, clone);
+            for (var key in value) {
+                if (contains(value, key)) {
+                    clone[key] = structuredCloneRecursive(value[key], objects);
+                }
+            }
+        }
+        return clone;
+    }
 })(collections = exports.collections || (exports.collections = {}));
 var strings;
 (function (strings) {
@@ -69,7 +92,7 @@ var graph;
         };
     }
     graph.newNode = newNode;
-    var Graph = (function () {
+    var Graph = /** @class */ (function () {
         function Graph(_hashFn) {
             this._hashFn = _hashFn;
             this._nodes = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import * as builder from './builder';
 import * as ts from 'typescript';
 import {Stream} from 'stream';
 import {readFileSync, existsSync, readdirSync} from 'fs';
-import {extname, dirname} from 'path';
+import {extname, dirname, resolve} from 'path';
 
 // We actually only want to read the tsconfig.json file. So all methods
 // to read the FS are 'empty' implementations.
@@ -36,12 +36,14 @@ export function create(configOrName: { [option: string]: string | number | boole
     let config: builder.IConfiguration = { json, verbose, noFilesystemLookup: false };
 
     if (typeof configOrName === 'string') {
-        var parsed = ts.readConfigFile(configOrName, _parseConfigHost.readFile);
-        options = ts.parseJsonConfigFileContent(parsed.config, _parseConfigHost, dirname(configOrName)).options;
+        let parsed = ts.readConfigFile(configOrName, _parseConfigHost.readFile);
         if (parsed.error) {
             console.error(parsed.error);
             return () => null;
         }
+
+        options = ts.parseJsonConfigFileContent(parsed.config, _parseConfigHost, dirname(configOrName), undefined, configOrName).options;
+        config.base = resolve(dirname(configOrName));
     } else {
         options = ts.parseJsonConfigFileContent({ compilerOptions: configOrName }, _parseConfigHost, './').options;
         Object.assign(config, configOrName);
@@ -50,6 +52,8 @@ export function create(configOrName: { [option: string]: string | number | boole
     if (!onError) {
         onError = (err) => console.log(JSON.stringify(err, null, 4));
     }
+
+    if (!config.base) config.base = process.cwd();
 
     const _builder = builder.createTypeScriptBuilder(config, options);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,10 +38,31 @@ export module collections {
     export function contains(collection: { [keys: string]: any }, key: string): boolean {
         return hasOwnProperty.call(collection, key);
     }
+
+    export function structuredClone<T>(value: T): T {
+        return structuredCloneRecursive(value, new Map<any, any>());
+    }
+
+    function structuredCloneRecursive(value: any, objects: Map<any, any>) {
+        if (value === undefined) return undefined;
+        if (value === null) return null;
+        if (typeof value !== "object") return value;
+        let clone = objects.get(value);
+        if (clone === undefined) {
+            clone = Array.isArray(value) ? Array<any>(value.length) : {};
+            objects.set(value, clone);
+            for (const key in value) {
+                if (contains(value, key)) {
+                    clone[key] = structuredCloneRecursive(value[key], objects);
+                }
+            }
+        }
+        return clone;
+    }
 }
 
 export module strings {
-	
+
 	/**
 	 * The empty string. The one and only.
 	 */


### PR DESCRIPTION
This PR includes only the necessary changes from https://github.com/jrieken/gulp-tsb/pull/45 to correctly emit source maps that work well with _gulp-sourcemaps_.

There are several issues with the source map emit provided by gulp-tsb that prevent _gulp-sourcemaps_ from properly handling the output:

- Both TypeScript **and** _gulp-sourcemaps_add a `sourceMappingURL` comment at the end of the file.
- TypeScript's `--inlineSourceMap` and `--inlineSources` options conflict with functionality provided by _gulp-sourcemaps_. When combined this can result in incorrect or inaccurate source maps.
- TypeScript's `--sourceRoot` and `--mapRoot` options are in direct conflict with the `write` function used by _gulp-sourcemaps_ that controls path mapping.
- Without a `--sourceRoot`, TypeScript emits all sourceMaps with the `"source"` property as the file name only, but _gulp-sourcemaps_ expects the `"source"` property to be relative to the base directory to correctly compute the output paths.
- TypeScript's `--outDir` conflicts with the `dest` function used by _gulp_.

The changes in this PR align TypeScript's sourcemap output with that expected by _gulp-sourcemaps_.
