### PR TITLE
Respect the basePath when passed via config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,12 @@ var _parseConfigHost = {
 };
 function create(configOrName, verbose, json, onError) {
     var options = ts.getDefaultCompilerOptions();
-    var config = { json: json, verbose: verbose, noFilesystemLookup: false };
+    var config = {
+        json: json,
+        verbose: verbose,
+        noFilesystemLookup: false,
+        base: process.cwd()
+    };
     if (typeof configOrName === 'string') {
         var parsed = ts.readConfigFile(configOrName, _parseConfigHost.readFile);
         if (parsed.error) {
@@ -33,14 +38,15 @@ function create(configOrName, verbose, json, onError) {
         config.base = path_1.resolve(path_1.dirname(configOrName));
     }
     else {
-        options = ts.parseJsonConfigFileContent({ compilerOptions: configOrName }, _parseConfigHost, './').options;
+        if (configOrName.base) {
+            config.base = configOrName.base;
+        }
+        options = ts.parseJsonConfigFileContent({ compilerOptions: configOrName }, _parseConfigHost, config.base).options;
         Object.assign(config, configOrName);
     }
     if (!onError) {
         onError = function (err) { return console.log(JSON.stringify(err, null, 4)); };
     }
-    if (!config.base)
-        config.base = process.cwd();
     var _builder = builder.createTypeScriptBuilder(config, options);
     function createStream(token) {
         return through(function (file) {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,11 +1,11 @@
 'use strict';
 
-import {Stats, statSync, readFileSync, existsSync} from 'fs';
+import { Stats, statSync, readFileSync, existsSync } from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
 import * as utils from './utils';
-import {EOL} from "os";
-import {log, colors} from 'gulp-util';
+import { EOL } from "os";
+import { log, colors } from 'gulp-util';
 import * as ts from 'typescript';
 import Vinyl = require('vinyl');
 
@@ -13,7 +13,7 @@ export interface IConfiguration {
     json: boolean;
     noFilesystemLookup: boolean;
     verbose: boolean;
-    base?: string;
+    base: string;
     _emitWithoutBasePath?: boolean;
     _emitLanguageService?: boolean;
 }
@@ -129,7 +129,7 @@ export function createTypeScriptBuilder(config: IConfiguration, compilerOptions:
         function checkSyntaxSoon(fileName: string): Promise<ts.Diagnostic[]> {
             return new Promise<ts.Diagnostic[]>(resolve => {
                 process.nextTick(function () {
-                      resolve(service.getSyntacticDiagnostics(fileName));
+                    resolve(service.getSyntacticDiagnostics(fileName));
                 });
             });
         }
@@ -137,15 +137,15 @@ export function createTypeScriptBuilder(config: IConfiguration, compilerOptions:
         function checkSemanticsSoon(fileName: string): Promise<ts.Diagnostic[]> {
             return new Promise<ts.Diagnostic[]>(resolve => {
                 process.nextTick(function () {
-                      resolve(service.getSemanticDiagnostics(fileName));
+                    resolve(service.getSemanticDiagnostics(fileName));
                 });
             });
         }
 
-        function emitSoon(fileName: string): Promise<{ fileName:string, signature: string, files: Vinyl[] }> {
+        function emitSoon(fileName: string): Promise<{ fileName: string, signature: string, files: Vinyl[] }> {
 
             return new Promise(resolve => {
-                process.nextTick(function() {
+                process.nextTick(function () {
 
                     if (/\.d\.ts$/.test(fileName)) {
                         // if it's already a d.ts file just emit it signature
@@ -345,7 +345,7 @@ export function createTypeScriptBuilder(config: IConfiguration, compilerOptions:
                             lastDtsHash[fileName] = value.signature;
                             filesWithChangedSignature.push(fileName);
                         }
-                     });
+                    });
                 }
 
                 // (2nd) check syntax
@@ -393,7 +393,7 @@ export function createTypeScriptBuilder(config: IConfiguration, compilerOptions:
                         let fileName = filesWithChangedSignature.pop();
 
                         if (!isExternalModule(service.getProgram().getSourceFile(fileName))) {
-                             _log('[check semantics*]', fileName + ' is an internal module and it has changed shape -> check whatever hasn\'t been checked yet');
+                            _log('[check semantics*]', fileName + ' is an internal module and it has changed shape -> check whatever hasn\'t been checked yet');
                             toBeCheckedSemantically.push(...host.getScriptFileNames());
                             filesWithChangedSignature.length = 0;
                             dependentFiles.length = 0;
@@ -523,7 +523,7 @@ class LanguageServiceHost implements ts.LanguageServiceHost {
     private _dependenciesRecomputeList: string[];
     private _fileNameToDeclaredModule: { [path: string]: string[] };
 
-    constructor(settings: ts.CompilerOptions, noFilesystemLookup:boolean) {
+    constructor(settings: ts.CompilerOptions, noFilesystemLookup: boolean) {
         this._settings = settings;
         this._noFilesystemLookup = noFilesystemLookup;
         this._snapshots = Object.create(null);
@@ -576,7 +576,7 @@ class LanguageServiceHost implements ts.LanguageServiceHost {
         let result = this._snapshots[filename];
         if (!result && !this._noFilesystemLookup) {
             try {
-                result = new ScriptSnapshot(new Vinyl(<any> {
+                result = new ScriptSnapshot(new Vinyl(<any>{
                     path: filename,
                     contents: readFileSync(filename),
                     base: this._settings.outDir,
@@ -608,7 +608,7 @@ class LanguageServiceHost implements ts.LanguageServiceHost {
             let match: RegExpExecArray;
             while ((match = LanguageServiceHost._declareModule.exec(snapshot.getText(0, snapshot.getLength())))) {
                 let declaredModules = this._fileNameToDeclaredModule[filename];
-                if(!declaredModules) {
+                if (!declaredModules) {
                     this._fileNameToDeclaredModule[filename] = declaredModules = [];
                 }
                 declaredModules.push(match[2]);
@@ -712,7 +712,7 @@ class LanguageServiceHost implements ts.LanguageServiceHost {
 
             if (!found) {
                 for (let key in this._fileNameToDeclaredModule) {
-                    if(this._fileNameToDeclaredModule[key] && ~this._fileNameToDeclaredModule[key].indexOf(ref.fileName)) {
+                    if (this._fileNameToDeclaredModule[key] && ~this._fileNameToDeclaredModule[key].indexOf(ref.fileName)) {
                         this._dependencies.inertEdge(filename, key);
                     }
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,9 @@ import vinyl = require('vinyl');
 import * as through from 'through';
 import * as builder from './builder';
 import * as ts from 'typescript';
-import {Stream} from 'stream';
-import {readFileSync, existsSync, readdirSync} from 'fs';
-import {extname, dirname, resolve} from 'path';
+import { Stream } from 'stream';
+import { readFileSync, existsSync, readdirSync } from 'fs';
+import { extname, dirname, resolve } from 'path';
 
 // We actually only want to read the tsconfig.json file. So all methods
 // to read the FS are 'empty' implementations.
@@ -33,7 +33,12 @@ export interface IncrementalCompiler {
 export function create(configOrName: { [option: string]: string | number | boolean; } | string, verbose?: boolean, json?: boolean, onError?: (message: any) => void): IncrementalCompiler {
 
     let options = ts.getDefaultCompilerOptions();
-    let config: builder.IConfiguration = { json, verbose, noFilesystemLookup: false };
+    let config: builder.IConfiguration = {
+        json,
+        verbose,
+        noFilesystemLookup: false,
+        base: process.cwd()
+    };
 
     if (typeof configOrName === 'string') {
         let parsed = ts.readConfigFile(configOrName, _parseConfigHost.readFile);
@@ -45,15 +50,17 @@ export function create(configOrName: { [option: string]: string | number | boole
         options = ts.parseJsonConfigFileContent(parsed.config, _parseConfigHost, dirname(configOrName), undefined, configOrName).options;
         config.base = resolve(dirname(configOrName));
     } else {
-        options = ts.parseJsonConfigFileContent({ compilerOptions: configOrName }, _parseConfigHost, './').options;
+        if (configOrName.base) {
+            config.base = configOrName.base as string;
+        }
+
+        options = ts.parseJsonConfigFileContent({ compilerOptions: configOrName }, _parseConfigHost, config.base).options;
         Object.assign(config, configOrName);
     }
 
     if (!onError) {
         onError = (err) => console.log(JSON.stringify(err, null, 4));
     }
-
-    if (!config.base) config.base = process.cwd();
 
     const _builder = builder.createTypeScriptBuilder(config, options);
 
@@ -75,5 +82,5 @@ export function create(configOrName: { [option: string]: string | number | boole
     let result = (token: builder.CancellationToken) => createStream(token);
     Object.defineProperty(result, 'program', { get: () => _builder.languageService.getProgram() });
 
-    return <IncrementalCompiler> result;
+    return <IncrementalCompiler>result;
 }


### PR DESCRIPTION
This forwards the `base` option of `gulp-tsb` as the `basePath` argument to `ts.parseJsonConfigFileContent`.

This is crucial for `@types` resolving. Currently, in https://github.com/Microsoft/vscode, all extension `@types` dependencies are being loaded from the root of the repository instead of from themselves. As a proof, simply create a syntax error in `node_modules/@types/node/index.d.ts` and run `git compile-extension:git`. It will fail on that file... when it should've been loading `extensions/git/node_modules/@types/node/index.d.ts` all along.

cc @mjbvz 