### PR TITLE
Respect the basePath when passed via config [based on release 2.0.4]

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -300,7 +300,7 @@ function createTypeScriptBuilder(config, compilerOptions) {
     };
 }
 exports.createTypeScriptBuilder = createTypeScriptBuilder;
-var ScriptSnapshot = (function () {
+var ScriptSnapshot = /** @class */ (function () {
     function ScriptSnapshot(text, mtime) {
         this._text = text;
         this._mtime = mtime;
@@ -319,7 +319,7 @@ var ScriptSnapshot = (function () {
     };
     return ScriptSnapshot;
 }());
-var VinylScriptSnapshot = (function (_super) {
+var VinylScriptSnapshot = /** @class */ (function (_super) {
     __extends(VinylScriptSnapshot, _super);
     function VinylScriptSnapshot(file) {
         var _this = _super.call(this, file.contents.toString(), file.stat.mtime) || this;
@@ -331,7 +331,7 @@ var VinylScriptSnapshot = (function (_super) {
     };
     return VinylScriptSnapshot;
 }(ScriptSnapshot));
-var LanguageServiceHost = (function () {
+var LanguageServiceHost = /** @class */ (function () {
     function LanguageServiceHost(settings, noFilesystemLookup) {
         this._settings = settings;
         this._noFilesystemLookup = noFilesystemLookup;

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,8 @@ function create(configOrName, verbose, json, onError) {
         }
     }
     else {
-        options = ts.parseJsonConfigFileContent({ compilerOptions: configOrName }, _parseConfigHost, './').options;
+        var base = typeof configOrName.base === 'string' ? configOrName.base : './';
+        options = ts.parseJsonConfigFileContent({ compilerOptions: configOrName }, _parseConfigHost, base).options;
         Object.assign(config, configOrName);
     }
     if (!onError) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -69,7 +69,7 @@ var graph;
         };
     }
     graph.newNode = newNode;
-    var Graph = (function () {
+    var Graph = /** @class */ (function () {
         function Graph(_hashFn) {
             this._hashFn = _hashFn;
             this._nodes = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,9 @@ import vinyl = require('vinyl');
 import * as through from 'through';
 import * as builder from './builder';
 import * as ts from 'typescript';
-import {Stream} from 'stream';
-import {readFileSync, existsSync, readdirSync} from 'fs';
-import {extname, dirname} from 'path';
+import { Stream } from 'stream';
+import { readFileSync, existsSync, readdirSync } from 'fs';
+import { extname, dirname } from 'path';
 
 // We actually only want to read the tsconfig.json file. So all methods
 // to read the FS are 'empty' implementations.
@@ -43,7 +43,8 @@ export function create(configOrName: { [option: string]: string | number | boole
             return () => null;
         }
     } else {
-        options = ts.parseJsonConfigFileContent({ compilerOptions: configOrName }, _parseConfigHost, './').options;
+        const base = typeof configOrName.base === 'string' ? configOrName.base : './';
+        options = ts.parseJsonConfigFileContent({ compilerOptions: configOrName }, _parseConfigHost, base).options;
         Object.assign(config, configOrName);
     }
 
@@ -71,5 +72,5 @@ export function create(configOrName: { [option: string]: string | number | boole
     let result = (token: builder.CancellationToken) => createStream(token);
     Object.defineProperty(result, 'program', { get: () => _builder.languageService.getProgram() });
 
-    return <IncrementalCompiler> result;
+    return <IncrementalCompiler>result;
 }


### PR DESCRIPTION
This is pretty much the same as #72 but it applies to a branch stemming off 2.0.4, which I called `release/2.0`.

The reason for this is that I tried bringing in the changes of #72 into VSCode and that failed for mysterious reasons. I don't want to take the time to look into that, so here's what I want:

- This PR should be merged onto the `release/2.0` branch and published to NPM as a patch: 2.0.5
- #72 should be merged onto `master` and eventually (no rush there) published to NPM as a minor: 2.1.x