### PR TITLE
replace deprecated gulp-util

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -5,7 +5,8 @@ var path = require("path");
 var crypto = require("crypto");
 var utils = require("./utils");
 var os_1 = require("os");
-var gulp_util_1 = require("gulp-util");
+var log = require("fancy-log");
+var colors = require("ansi-colors");
 var ts = require("typescript");
 var Vinyl = require("vinyl");
 var CancellationToken;
@@ -38,7 +39,7 @@ function createTypeScriptBuilder(config, compilerOptions) {
     host.getCompilationSettings().declaration = true;
     function _log(topic, message) {
         if (config.verbose) {
-            gulp_util_1.log(gulp_util_1.colors.cyan(topic), message);
+            log(colors.cyan(topic), message);
         }
     }
     function printDiagnostic(diag, onError) {
@@ -363,7 +364,7 @@ function createTypeScriptBuilder(config, compilerOptions) {
             // print stats
             if (config.verbose) {
                 var headNow = process.memoryUsage().heapUsed, MB = 1024 * 1024;
-                gulp_util_1.log('[tsb]', 'time:', gulp_util_1.colors.yellow((Date.now() - t1) + 'ms'), 'mem:', gulp_util_1.colors.cyan(Math.ceil(headNow / MB) + 'MB'), gulp_util_1.colors.bgCyan('Δ' + Math.ceil((headNow - headUsed) / MB)));
+                log('[tsb]', 'time:', colors.yellow((Date.now() - t1) + 'ms'), 'mem:', colors.cyan(Math.ceil(headNow / MB) + 'MB'), colors.bgcyan('Δ' + Math.ceil((headNow - headUsed) / MB)));
                 headUsed = headNow;
             }
         });

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
     "incremental"
   ],
   "dependencies": {
-    "gulp-util": "^3.0.1",
+    "ansi-colors": "^1.0.1",
+    "fancy-log": "^1.3.2",
     "through": "^2.3.6",
-    "vinyl": "^0.4.3"
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "@types/chalk": "*",
@@ -32,11 +33,11 @@
     "@types/node": "*",
     "@types/through": "*",
     "@types/vinyl": "*",
-    "del": "^2.2.2",
+    "del": "^3.0.0",
     "gulp": "^3.8.10",
-    "gulp-mocha": "^3.0.1",
+    "gulp-mocha": "^5.0.0",
     "mocha": "*",
-    "run-sequence": "^1.2.2",
+    "run-sequence": "^2.2.1",
     "typescript": "^2.0.3"
   },
   "peerDependencies": {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -5,7 +5,8 @@ import * as path from 'path';
 import * as crypto from 'crypto';
 import * as utils from './utils';
 import { EOL } from "os";
-import { log, colors } from 'gulp-util';
+import * as log from 'fancy-log';
+import * as colors from 'ansi-colors';
 import * as ts from 'typescript';
 import Vinyl = require('vinyl');
 
@@ -464,7 +465,7 @@ export function createTypeScriptBuilder(config: IConfiguration, compilerOptions:
                     MB = 1024 * 1024;
                 log('[tsb]',
                     'time:', colors.yellow((Date.now() - t1) + 'ms'),
-                    'mem:', colors.cyan(Math.ceil(headNow / MB) + 'MB'), colors.bgCyan('Δ' + Math.ceil((headNow - headUsed) / MB)));
+                    'mem:', colors.cyan(Math.ceil(headNow / MB) + 'MB'), colors.bgcyan('Δ' + Math.ceil((headNow - headUsed) / MB)));
                 headUsed = headNow;
             }
         });


### PR DESCRIPTION
## Proposed changes

Update dependencies and fix deprecation message:
```
npm WARN deprecated gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
```

## Further comments
Use instructions from https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
  
  