### PR TITLE
Allows passing through custom transforms

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -27,8 +27,8 @@ var CancellationToken;
 function normalize(path) {
     return path.replace(/\\/g, '/');
 }
-function createTypeScriptBuilder(config, compilerOptions) {
-    var host = new LanguageServiceHost(compilerOptions, config.noFilesystemLookup || false), service = ts.createLanguageService(host, ts.createDocumentRegistry()), lastBuildVersion = Object.create(null), lastDtsHash = Object.create(null), userWantsDeclarations = compilerOptions.declaration, oldErrors = Object.create(null), headUsed = process.memoryUsage().heapUsed, emitSourceMapsInStream = true;
+function createTypeScriptBuilder(config, compilerOptions, customTransforms) {
+    var host = new LanguageServiceHost(compilerOptions, config.noFilesystemLookup || false, customTransforms), service = ts.createLanguageService(host, ts.createDocumentRegistry()), lastBuildVersion = Object.create(null), lastDtsHash = Object.create(null), userWantsDeclarations = compilerOptions.declaration, oldErrors = Object.create(null), headUsed = process.memoryUsage().heapUsed, emitSourceMapsInStream = true;
     // always emit declaraction files
     host.getCompilationSettings().declaration = true;
     function _log(topic, message) {
@@ -333,7 +333,7 @@ var VinylScriptSnapshot = /** @class */ (function (_super) {
     return VinylScriptSnapshot;
 }(ScriptSnapshot));
 var LanguageServiceHost = /** @class */ (function () {
-    function LanguageServiceHost(settings, noFilesystemLookup) {
+    function LanguageServiceHost(settings, noFilesystemLookup, customTransforms) {
         this._settings = settings;
         this._noFilesystemLookup = noFilesystemLookup;
         this._snapshots = Object.create(null);
@@ -341,6 +341,7 @@ var LanguageServiceHost = /** @class */ (function () {
         this._dependencies = new utils.graph.Graph(function (s) { return s; });
         this._dependenciesRecomputeList = [];
         this._fileNameToDeclaredModule = Object.create(null);
+        this._customTransforms = customTransforms;
     }
     LanguageServiceHost.prototype.log = function (s) {
         // nothing
@@ -433,6 +434,9 @@ var LanguageServiceHost = /** @class */ (function () {
                 // false so this method never throws
             }
         };
+    };
+    LanguageServiceHost.prototype.getCustomTransformers = function () {
+        return this._customTransforms;
     };
     LanguageServiceHost.prototype.getCurrentDirectory = function () {
         return process.cwd();

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ var _parseConfigHost = {
         return fs_1.readFileSync(fileName, 'utf-8');
     },
 };
-function create(configOrName, verbose, json, onError) {
+function create(configOrName, customTransformers, verbose, json, onError) {
     var options = ts.getDefaultCompilerOptions();
     var config = { json: json, verbose: verbose, noFilesystemLookup: false };
     if (typeof configOrName === 'string') {
@@ -39,7 +39,7 @@ function create(configOrName, verbose, json, onError) {
     if (!onError) {
         onError = function (err) { return console.log(JSON.stringify(err, null, 4)); };
     }
-    var _builder = builder.createTypeScriptBuilder(config, options);
+    var _builder = builder.createTypeScriptBuilder(config, options, customTransformers);
     function createStream(token) {
         return through(function (file) {
             // give the file to the compiler

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ export interface IncrementalCompiler {
     program?: ts.Program;
 }
 
-export function create(configOrName: { [option: string]: string | number | boolean; } | string, verbose?: boolean, json?: boolean, onError?: (message: any) => void): IncrementalCompiler {
+export function create(configOrName: { [option: string]: string | number | boolean; } | string, customTransformers?: ts.CustomTransformers, verbose?: boolean, json?: boolean, onError?: (message: any) => void): IncrementalCompiler {
 
     let options = ts.getDefaultCompilerOptions();
     let config: builder.IConfiguration = { json, verbose, noFilesystemLookup: false };
@@ -52,7 +52,7 @@ export function create(configOrName: { [option: string]: string | number | boole
         onError = (err) => console.log(JSON.stringify(err, null, 4));
     }
 
-    const _builder = builder.createTypeScriptBuilder(config, options);
+    const _builder = builder.createTypeScriptBuilder(config, options, customTransformers);
 
     function createStream(token?: builder.CancellationToken): Stream {
 


### PR DESCRIPTION
Wasn't sure which branch to base off of as it seems release/2.0 as diverged from master quite a bit.

As the title states, simply pipes through a customer transformers option from creation to the language service.